### PR TITLE
fix: Proper dsiplay of carousel

### DIFF
--- a/public/src/assets/css/style.css
+++ b/public/src/assets/css/style.css
@@ -87,10 +87,6 @@ a.box:focus {
     Carousel styling.
 */
 
-.el-carousel__container {
-  height: 550px!important;
-}
-
 .el-carousel__item img {
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
- Set carousel container height to 550px
- Centere image within carousel
- Image now no longer gets cropped
- Image preserves aspect ratio.
Connects to #174 
